### PR TITLE
Fix for namespace change in Statamic 2.10

### DIFF
--- a/Version/Outpost.php
+++ b/Version/Outpost.php
@@ -21,7 +21,8 @@ trait Outpost
 
     public function __construct()
     {
-        $this->outpost = app('Statamic\Outpost');
+        $outpost = version_compare(STATAMIC_VERSION, '2.10.0', '<') ? 'Statamic\Outpost' : 'Statamic\Outpost\Outpost';
+        $this->outpost = app($outpost);
         $this->outpost->radio();
     }
 


### PR DESCRIPTION
This fixes an error users would get see when using the console in 2.10